### PR TITLE
http: mark str with [[maybe_unused]]

### DIFF
--- a/src/http/request_parser.rl
+++ b/src/http/request_parser.rl
@@ -150,7 +150,7 @@ public:
     }
     char* parse(char* p, char* pe, char* eof) {
         sstring_builder::guard g(_builder, p, pe);
-        auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
+        [[maybe_unused]] auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
         bool done = false;
         if (p != pe) {
             _state = state::error;


### PR DESCRIPTION
not all execution code defined by the "action" statements references the defined `str` lambda, so compiler might warn at seeing unused variable. with compiling options of `-Werror,-Wunused-variable`, this even fails the build.

so, in this change, the `str` lambda is marked with `[[maybe_unused]]` to silence the warning and to fix the FTBFS.

Fixes #1262
Signed-off-by: Kefu Chai <tchaikov@gmail.com>